### PR TITLE
Implement process factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,9 +366,9 @@ return (new PhpCsFixer\Config())
                 // A codec for handling placeholers in template strings; depends on the content being formatted.
                 interpolationCodec: new PlainStringCodec(),
                 // A normalizer for handling end-of-line characters.
-                lineEndingNormalizer: null
+                lineEndingNormalizer: null,
                 // Factory for creating processes. Defaults to Symfony process factory.
-                processFactory = null,
+                processFactory: null,
             )
         ]),
     ]);
@@ -406,7 +406,7 @@ return (new PhpCsFixer\Config())
                 // A normalizer for handling end-of-line characters.
                 lineEndingNormalizer: null,
                 // Factory for creating processes. Defaults to Symfony process factory.
-                processFactory = null,
+                processFactory: null,
             )
         ]),
     ]);

--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ return (new PhpCsFixer\Config())
                 interpolationCodec: new PlainStringCodec(),
                 // A normalizer for handling end-of-line characters.
                 lineEndingNormalizer: null
+                // Factory for creating processes. Defaults to Symfony process factory.
+                processFactory = null,
             )
         ]),
     ]);
@@ -403,6 +405,8 @@ return (new PhpCsFixer\Config())
                 interpolationCodec: new PlainStringCodec(),
                 // A normalizer for handling end-of-line characters.
                 lineEndingNormalizer: null,
+                // Factory for creating processes. Defaults to Symfony process factory.
+                processFactory = null,
             )
         ]),
     ]);

--- a/src/Formatter/CliPipeFormatter.php
+++ b/src/Formatter/CliPipeFormatter.php
@@ -27,9 +27,9 @@ use uuf6429\PhpCsFixerBlockstring\Process\SymfonyProcessFactory;
  *                 // A codec for handling placeholers in template strings; depends on the content being formatted.
  *                 interpolationCodec: new PlainStringCodec(),
  *                 // A normalizer for handling end-of-line characters.
- *                 lineEndingNormalizer: null
+ *                 lineEndingNormalizer: null,
  *                 // Factory for creating processes. Defaults to Symfony process factory.
- *                 processFactory = null,
+ *                 processFactory: null,
  *             )
  *         ]),
  *     ]);

--- a/src/Formatter/CliPipeFormatter.php
+++ b/src/Formatter/CliPipeFormatter.php
@@ -2,10 +2,11 @@
 
 namespace uuf6429\PhpCsFixerBlockstring\Formatter;
 
-use Symfony\Component\Process\Process;
 use uuf6429\PhpCsFixerBlockstring\InterpolationCodec\CodecInterface;
 use uuf6429\PhpCsFixerBlockstring\LineEndingNormalizer\DefaultNormalizer;
 use uuf6429\PhpCsFixerBlockstring\LineEndingNormalizer\NormalizerInterface;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessFactoryInterface;
+use uuf6429\PhpCsFixerBlockstring\Process\SymfonyProcessFactory;
 
 /**
  * It's no secret that the best formatting tools are not directly available in PHP. This formatter off-loads formatting
@@ -27,6 +28,8 @@ use uuf6429\PhpCsFixerBlockstring\LineEndingNormalizer\NormalizerInterface;
  *                 interpolationCodec: new PlainStringCodec(),
  *                 // A normalizer for handling end-of-line characters.
  *                 lineEndingNormalizer: null
+ *                 // Factory for creating processes. Defaults to Symfony process factory.
+ *                 processFactory = null,
  *             )
  *         ]),
  *     ]);
@@ -50,31 +53,24 @@ class CliPipeFormatter extends AbstractStringFormatter
 	private array $formatter;
 
 	/**
+	 * @readonly
+	 */
+	private ProcessFactoryInterface $processFactory;
+
+	/**
 	 * @param TVersion|TCommand $versionValueOrCommand Either the version (as a string) or a command to retrieve the
 	 * version (as an array).
 	 * @param TCommand $formatCommand A command, as an array, to perform the formatting.
-	 * @param null|bool|NormalizerInterface $lineEndingNormalizer
 	 */
 	public function __construct(
 		$versionValueOrCommand,
 		array $formatCommand,
 		?CodecInterface $interpolationCodec = null,
-		$lineEndingNormalizer = false
+		?NormalizerInterface $lineEndingNormalizer = null,
+		?ProcessFactoryInterface $processFactory = null
 	) {
 		$this->formatter = $formatCommand;
-
-		if (is_bool($lineEndingNormalizer)) {
-			trigger_deprecation(
-				'uuf6429/php-cs-fixer-blockstring',
-				'1.0.4',
-				'Passing a bool for argument $lineEndingNormalizer to %s is deprecated',
-				__METHOD__
-			);
-			$lineEndingNormalizer = new DefaultNormalizer(
-				DefaultNormalizer::LF,
-				$lineEndingNormalizer ? DefaultNormalizer::STRIP : DefaultNormalizer::NO_CHANGE
-			);
-		}
+		$this->processFactory = $processFactory ?? new SymfonyProcessFactory();
 
 		parent::__construct(
 			sprintf(
@@ -88,7 +84,7 @@ class CliPipeFormatter extends AbstractStringFormatter
 					: $this->exec($versionValueOrCommand, null)
 			),
 			$interpolationCodec,
-			$lineEndingNormalizer
+			$lineEndingNormalizer ?? new DefaultNormalizer(DefaultNormalizer::LF, DefaultNormalizer::NO_CHANGE)
 		);
 	}
 
@@ -97,23 +93,15 @@ class CliPipeFormatter extends AbstractStringFormatter
 	 */
 	protected function exec(array $spec, ?string $input): string
 	{
-		$process = is_array($spec['cmd'])
-			? new Process(
+		return $this->processFactory
+			->create(
 				$spec['cmd'],
 				$spec['cwd'] ?? null,
 				$spec['env'] ?? null,
-				$input,
-				null
+				$input
 			)
-			: Process::fromShellCommandline(
-				$spec['cmd'],
-				$spec['cwd'] ?? null,
-				$spec['env'] ?? null,
-				$input,
-				null
-			);
-
-		return $process->mustRun()->getOutput();
+			->mustRun()
+			->getOutput();
 	}
 
 	protected function formatContent(string $original): string

--- a/src/Formatter/DockerPipeFormatter.php
+++ b/src/Formatter/DockerPipeFormatter.php
@@ -4,11 +4,12 @@ namespace uuf6429\PhpCsFixerBlockstring\Formatter;
 
 use InvalidArgumentException;
 use RuntimeException;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
 use uuf6429\PhpCsFixerBlockstring\InterpolationCodec\CodecInterface;
 use uuf6429\PhpCsFixerBlockstring\LineEndingNormalizer\DefaultNormalizer;
 use uuf6429\PhpCsFixerBlockstring\LineEndingNormalizer\NormalizerInterface;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessFactoryInterface;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessFailedException;
+use uuf6429\PhpCsFixerBlockstring\Process\SymfonyProcessFactory;
 
 /**
  * The minimal setup, stable repeatability, and a rich ecosystem make Docker images an ideal source of formatting
@@ -34,6 +35,8 @@ use uuf6429\PhpCsFixerBlockstring\LineEndingNormalizer\NormalizerInterface;
  *                 interpolationCodec: new PlainStringCodec(),
  *                 // A normalizer for handling end-of-line characters.
  *                 lineEndingNormalizer: null,
+ *                 // Factory for creating processes. Defaults to Symfony process factory.
+ *                 processFactory = null,
  *             )
  *         ]),
  *     ]);
@@ -73,37 +76,30 @@ class DockerPipeFormatter extends AbstractStringFormatter
 	private array $imageDetails;
 
 	/**
+	 * @readonly
+	 */
+	private ProcessFactoryInterface $processFactory;
+
+	/**
 	 * @param list<string> $options
 	 * @param list<string> $command
 	 * @param 'never'|'missing'|'always' $pullMode
-	 * @param null|bool|NormalizerInterface $lineEndingNormalizer
 	 */
 	public function __construct(
-		string          $image,
-		array           $options = [],
-		array           $command = [],
-		string          $pullMode = 'never',
-		?CodecInterface $interpolationCodec = null,
-		                $lineEndingNormalizer = true
+		string                   $image,
+		array                    $options = [],
+		array                    $command = [],
+		string                   $pullMode = 'never',
+		?CodecInterface          $interpolationCodec = null,
+		?NormalizerInterface     $lineEndingNormalizer = null,
+		?ProcessFactoryInterface $processFactory = null
 	) {
 		$this->image = $image;
 		$this->options = $options;
 		$this->command = $command;
 		$this->pullMode = $pullMode;
+		$this->processFactory = $processFactory ?? new SymfonyProcessFactory();
 		$this->imageDetails = $this->resolveImageDetails();
-
-		if (is_bool($lineEndingNormalizer)) {
-			trigger_deprecation(
-				'uuf6429/php-cs-fixer-blockstring',
-				'1.0.4',
-				'Passing a bool for argument $lineEndingNormalizer to %s is deprecated',
-				__METHOD__
-			);
-			$lineEndingNormalizer = new DefaultNormalizer(
-				DefaultNormalizer::LF,
-				$lineEndingNormalizer ? DefaultNormalizer::STRIP : DefaultNormalizer::NO_CHANGE
-			);
-		}
 
 		parent::__construct(
 			sprintf(
@@ -119,7 +115,7 @@ class DockerPipeFormatter extends AbstractStringFormatter
 				)
 			),
 			$interpolationCodec,
-			$lineEndingNormalizer
+			$lineEndingNormalizer ?? new DefaultNormalizer(DefaultNormalizer::LF, DefaultNormalizer::STRIP)
 		);
 	}
 
@@ -139,7 +135,7 @@ class DockerPipeFormatter extends AbstractStringFormatter
 				}
 				$this->pullImage();
 				return $this->inspectImage(true);
-			// @codeCoverageIgnoreEnd
+				// @codeCoverageIgnoreEnd
 
 			case 'always':
 				$this->pullImage();
@@ -155,17 +151,12 @@ class DockerPipeFormatter extends AbstractStringFormatter
 	 */
 	private function inspectImage(bool $throwOnFailure): ?array
 	{
-		$process = new Process(
-			['docker', 'image', 'inspect', $this->image, '--format={{.Os}}/{{.Architecture}} {{.Id}}'],
-			null,
-			null,
-			null,
-			null
+		$process = $this->processFactory->create(
+			['docker', 'image', 'inspect', $this->image, '--format={{.Os}}/{{.Architecture}} {{.Id}}']
 		);
 		try {
 			$result = $process->mustRun()->getOutput();
 			$result = explode(' ', trim($result), 2);
-
 			return ['platform' => $result[0], 'digest' => $result[1]];
 		} catch (ProcessFailedException $ex) {
 			if (!$throwOnFailure) {
@@ -179,33 +170,28 @@ class DockerPipeFormatter extends AbstractStringFormatter
 
 	private function pullImage(): void
 	{
-		(new Process(
-			['docker', 'image', 'pull', $this->image],
-			null,
-			null,
-			null,
-			null
-		))->mustRun();
+		$this->processFactory
+			->create(['docker', 'image', 'pull', $this->image])
+			->mustRun();
 	}
 
 	protected function formatContent(string $original): string
 	{
-		$process = new Process(
-			[
-				'docker',
-				'run',
-				'--rm',
-				'--interactive',
-				...$this->options,
-				$this->imageDetails['digest'],
-				...$this->command,
-			],
-			null,
-			null,
-			$original,
-			null
-		);
-
-		return $process->mustRun()->getOutput();
+		return $this->processFactory
+			->create(
+				[
+					'docker',
+					'run',
+					'--rm',
+					'--interactive',
+					...$this->options,
+					$this->imageDetails['digest'],
+					...$this->command,
+				],
+				null,
+				null,
+				$original
+			)->mustRun()
+			->getOutput();
 	}
 }

--- a/src/Formatter/DockerPipeFormatter.php
+++ b/src/Formatter/DockerPipeFormatter.php
@@ -36,7 +36,7 @@ use uuf6429\PhpCsFixerBlockstring\Process\SymfonyProcessFactory;
  *                 // A normalizer for handling end-of-line characters.
  *                 lineEndingNormalizer: null,
  *                 // Factory for creating processes. Defaults to Symfony process factory.
- *                 processFactory = null,
+ *                 processFactory: null,
  *             )
  *         ]),
  *     ]);

--- a/src/Formatter/WslPipeFormatter.php
+++ b/src/Formatter/WslPipeFormatter.php
@@ -5,6 +5,7 @@ namespace uuf6429\PhpCsFixerBlockstring\Formatter;
 use uuf6429\PhpCsFixerBlockstring\InterpolationCodec\CodecInterface;
 use uuf6429\PhpCsFixerBlockstring\LineEndingNormalizer\DefaultNormalizer;
 use uuf6429\PhpCsFixerBlockstring\LineEndingNormalizer\NormalizerInterface;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessFactoryInterface;
 
 /**
  * A formatter making use of Windows Subsystem for Linux (WSL). Of course, you will need to be running on Windows,
@@ -20,31 +21,24 @@ class WslPipeFormatter extends CliPipeFormatter
 
 	/**
 	 * @param 'standard'|'login'|'none' $shellType
-	 * @param null|bool|NormalizerInterface $lineEndingNormalizer
 	 */
 	public function __construct(
 		$versionValueOrCommand,
 		array $formatCommand,
 		?CodecInterface $interpolationCodec = null,
 		string $shellType = 'login',
-		$lineEndingNormalizer = true
+		?NormalizerInterface $lineEndingNormalizer = null,
+		?ProcessFactoryInterface $processFactory = null
 	) {
 		$this->shellType = $shellType;
 
-		if (is_bool($lineEndingNormalizer)) {
-			trigger_deprecation(
-				'uuf6429/php-cs-fixer-blockstring',
-				'1.0.4',
-				'Passing a bool for argument $lineEndingNormalizer to %s is deprecated',
-				__METHOD__
-			);
-			$lineEndingNormalizer = new DefaultNormalizer(
-				DefaultNormalizer::LF,
-				$lineEndingNormalizer ? DefaultNormalizer::STRIP : DefaultNormalizer::NO_CHANGE
-			);
-		}
-
-		parent::__construct($versionValueOrCommand, $formatCommand, $interpolationCodec, $lineEndingNormalizer);
+		parent::__construct(
+			$versionValueOrCommand,
+			$formatCommand,
+			$interpolationCodec,
+			$lineEndingNormalizer ?? new DefaultNormalizer(DefaultNormalizer::LF, DefaultNormalizer::STRIP),
+			$processFactory
+		);
 	}
 
 	protected function exec(array $spec, ?string $input): string

--- a/src/Process/ProcessFactoryInterface.php
+++ b/src/Process/ProcessFactoryInterface.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace uuf6429\PhpCsFixerBlockstring\Process;
+
+interface ProcessFactoryInterface
+{
+	/**
+	 * @param string|list<string> $command
+	 * @param null|array<string, string> $env
+	 */
+	public function create(
+		$command,
+		?string $cwd = null,
+		?array $env = null,
+		?string $input = null
+	): ProcessInterface;
+}

--- a/src/Process/ProcessFailedException.php
+++ b/src/Process/ProcessFailedException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace uuf6429\PhpCsFixerBlockstring\Process;
+
+use RuntimeException;
+
+class ProcessFailedException extends RuntimeException
+{
+
+}

--- a/src/Process/ProcessInterface.php
+++ b/src/Process/ProcessInterface.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace uuf6429\PhpCsFixerBlockstring\Process;
+
+interface ProcessInterface
+{
+	/**
+	 * @throws ProcessFailedException
+	 */
+	public function mustRun(): self;
+
+	public function getOutput(): string;
+
+	public function getErrorOutput(): string;
+}

--- a/src/Process/SymfonyProcess.php
+++ b/src/Process/SymfonyProcess.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace uuf6429\PhpCsFixerBlockstring\Process;
+
+use Symfony\Component\Process\Exception\ProcessFailedException as SymfonyProcessFailedException;
+use Symfony\Component\Process\Process;
+
+final class SymfonyProcess implements ProcessInterface
+{
+	/**
+	 * @readonly
+	 */
+	private Process $process;
+
+	public function __construct(Process $process)
+	{
+		$this->process = $process;
+	}
+
+	public function mustRun(): self
+	{
+		try {
+			$this->process->mustRun();
+		} catch (SymfonyProcessFailedException $e) {
+			throw new ProcessFailedException("Process failed to run {$e->getMessage()}", 0, $e);
+		}
+
+		return $this;
+	}
+
+	public function getOutput(): string
+	{
+		return $this->process->getOutput();
+	}
+
+	public function getErrorOutput(): string
+	{
+		return $this->process->getErrorOutput();
+	}
+}

--- a/src/Process/SymfonyProcessFactory.php
+++ b/src/Process/SymfonyProcessFactory.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace uuf6429\PhpCsFixerBlockstring\Process;
+
+use Symfony\Component\Process\Process;
+
+final class SymfonyProcessFactory implements ProcessFactoryInterface
+{
+	/**
+	 * @readonly
+	 */
+	private ?float $timeout;
+
+	public function __construct(?float $timeout = null)
+	{
+		$this->timeout = $timeout;
+	}
+
+	public function create(
+		$command,
+		?string $cwd = null,
+		?array $env = null,
+		?string $input = null
+	): ProcessInterface {
+		return new SymfonyProcess(
+			is_array($command)
+				? new Process($command, $cwd, $env, $input, $this->timeout)
+				: Process::fromShellCommandline($command, $cwd, $env, $input, $this->timeout)
+		);
+	}
+}

--- a/tests/Integration/DockerPipeFormatterTest.php
+++ b/tests/Integration/DockerPipeFormatterTest.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace uuf6429\PhpCsFixerBlockstringTests\Integration;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use uuf6429\PhpCsFixerBlockstring\BlockString\BlockString;
+use uuf6429\PhpCsFixerBlockstring\BlockString\StringSegment;
+use uuf6429\PhpCsFixerBlockstring\Formatter\DockerPipeFormatter;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessFailedException;
+
+/**
+ * @internal
+ */
+final class DockerPipeFormatterTest extends TestCase
+{
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		if (PHP_OS_FAMILY === 'Windows' && getenv('GITHUB_ACTIONS') === 'true') {
+			$this->markTestSkipped(
+				'GitHub actions are not able to run non-Windows docker images: https://github.com/orgs/community/discussions/138554'
+			);
+		}
+	}
+
+	public function testFormat(): void
+	{
+		$formatter = new DockerPipeFormatter('ghcr.io/jqlang/jq', [], [], 'always');
+		$inputBlockString = new BlockString('', '', [new StringSegment(
+			"  {\"hello\"\n   : 	\"world\" , \"bye\":[  \"mars\" \n ]}"
+		)]);
+
+		$outputBlockString = $formatter->formatBlock($inputBlockString);
+
+		$this->assertSame(
+			<<<'JSON'
+			{
+			  "hello": "world",
+			  "bye": [
+			    "mars"
+			  ]
+			}
+			JSON,
+			implode('', $outputBlockString->segments)
+		);
+	}
+
+	public function testBadPullMode(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+
+		// @phpstan-ignore argument.type
+		new DockerPipeFormatter('ghcr.io/jqlang/jq', [], [], 'bad');
+	}
+
+	public function testBadImageWithoutPulling(): void
+	{
+		$this->expectException(RuntimeException::class);
+
+		new DockerPipeFormatter('docker.io/uuf6429/bad-image', [], [], 'never');
+	}
+
+	public function testBadImageWithMissingPulling(): void
+	{
+		$this->expectException(ProcessFailedException::class);
+
+		new DockerPipeFormatter('docker.io/uuf6429/bad-image', [], [], 'missing');
+	}
+}

--- a/tests/MockProcessFactoryTrait.php
+++ b/tests/MockProcessFactoryTrait.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+
+namespace uuf6429\PhpCsFixerBlockstringTests;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessFactoryInterface;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessFailedException;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessInterface;
+
+/**
+ * @internal
+ * @phpstan-require-extends TestCase
+ */
+trait MockProcessFactoryTrait
+{
+	/**
+	 * @param list<array{list<mixed>, ProcessInterface}> $processesToCreate
+	 * @return ProcessFactoryInterface
+	 */
+	private function createProcessFactoryMock(array $processesToCreate): ProcessFactoryInterface
+	{
+		$processFactory = $this->createMock(ProcessFactoryInterface::class);
+		$processFactory->method('create')
+			->willReturnCallback(function () use ($processesToCreate) {
+				$actualArgs = func_get_args();
+				foreach ($processesToCreate as [$expectedArgs, $resultingProcess]) {
+					if ($actualArgs === $expectedArgs) {
+						return $resultingProcess;
+					}
+				}
+
+				throw new RuntimeException(sprintf(
+					'Unexpected call to ProcessFactory::create(%s)',
+					implode(', ', array_map(static fn($arg) => var_export($arg, true), $actualArgs))
+				));
+			});
+
+		return $processFactory;
+	}
+
+	private function createProcessMock(string $output = '', string $errorOutput = ''): ProcessInterface
+	{
+		$process = $this->createMock(ProcessInterface::class);
+		$process->method('mustRun')->willReturnSelf();
+		$process->method('getOutput')->willReturn($output);
+		$process->method('getErrorOutput')->willReturn($errorOutput);
+
+		return $process;
+	}
+
+	private function createFailingProcessMock(string $errorOutput = ''): ProcessInterface
+	{
+		$process = $this->createMock(ProcessInterface::class);
+		$process->method('mustRun')->willThrowException(new ProcessFailedException('Process failed to run'));
+		$process->method('getErrorOutput')->willReturn($errorOutput);
+
+		return $process;
+	}
+}

--- a/tests/Unit/Fixer/BlockStringFixerTest.php
+++ b/tests/Unit/Fixer/BlockStringFixerTest.php
@@ -47,6 +47,11 @@ final class BlockStringFixerTest extends TestCase
 		(new BlockStringFixer())->getConfigurationDefinition();
 	}
 
+	public function testConfigDsl(): void
+	{
+		$this->assertSame(['formatters' => []], BlockStringFixer::config([]));
+	}
+
 	/**
 	 * @param mixed $formatters
 	 * @dataProvider invalidConfigurationProvider

--- a/tests/Unit/Formatter/CliPipeFormatterTest.php
+++ b/tests/Unit/Formatter/CliPipeFormatterTest.php
@@ -6,17 +6,32 @@ use PHPUnit\Framework\TestCase;
 use uuf6429\PhpCsFixerBlockstring\BlockString\BlockString;
 use uuf6429\PhpCsFixerBlockstring\BlockString\StringSegment;
 use uuf6429\PhpCsFixerBlockstring\Formatter\CliPipeFormatter;
+use uuf6429\PhpCsFixerBlockstringTests\MockProcessFactoryTrait;
 
 /**
  * @internal
  */
 final class CliPipeFormatterTest extends TestCase
 {
+	use MockProcessFactoryTrait;
+
 	public function testFormat(): void
 	{
 		$formatter = new CliPipeFormatter(
 			['cmd' => 'php -v'],
-			['cmd' => ['php', '-r', 'echo "(" . stream_get_contents(STDIN) . ")";']]
+			['cmd' => ['php', '-r', 'echo "(" . stream_get_contents(STDIN) . ")";']],
+			null,
+			null,
+			$this->createProcessFactoryMock([
+				[
+					['php -v', null, null, null],
+					$this->createProcessMock('v1.0'),
+				],
+				[
+					[['php', '-r', 'echo "(" . stream_get_contents(STDIN) . ")";'], null, null, 'foo'],
+					$this->createProcessMock('(foo)'),
+				]
+			])
 		);
 		$inputBlockString = new BlockString('', '', [new StringSegment('foo')]);
 
@@ -29,7 +44,15 @@ final class CliPipeFormatterTest extends TestCase
 	{
 		$formatter = new CliPipeFormatter(
 			'some version',
-			['cmd' => ['php', '-r', 'echo "(" . stream_get_contents(STDIN) . ")";']]
+			['cmd' => ['php', '-r', 'echo "(" . stream_get_contents(STDIN) . ")";']],
+			null,
+			null,
+			$this->createProcessFactoryMock([
+				[
+					[['php', '-r', 'echo "(" . stream_get_contents(STDIN) . ")";'], null, null, 'foo'],
+					$this->createProcessMock('(foo)'),
+				]
+			])
 		);
 		$inputBlockString = new BlockString('', '', [new StringSegment('foo')]);
 

--- a/tests/Unit/Formatter/DockerPipeFormatterTest.php
+++ b/tests/Unit/Formatter/DockerPipeFormatterTest.php
@@ -5,68 +5,135 @@ namespace uuf6429\PhpCsFixerBlockstringTests\Unit\Formatter;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Symfony\Component\Process\Exception\ProcessFailedException;
 use uuf6429\PhpCsFixerBlockstring\BlockString\BlockString;
 use uuf6429\PhpCsFixerBlockstring\BlockString\StringSegment;
 use uuf6429\PhpCsFixerBlockstring\Formatter\DockerPipeFormatter;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessFactoryInterface;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessFailedException;
+use uuf6429\PhpCsFixerBlockstring\Process\ProcessInterface;
+use uuf6429\PhpCsFixerBlockstringTests\MockProcessFactoryTrait;
 
 /**
  * @internal
  */
 final class DockerPipeFormatterTest extends TestCase
 {
-	protected function setUp(): void
+	use MockProcessFactoryTrait;
+
+	public function testFormatWithNeverPullMode(): void
 	{
-		parent::setUp();
-
-		if (PHP_OS_FAMILY === 'Windows' && getenv('GITHUB_ACTIONS') === 'true') {
-			$this->markTestSkipped(
-				'GitHub actions are not able to run non-Windows docker images: https://github.com/orgs/community/discussions/138554'
-			);
-		}
-	}
-
-	public function testFormat(): void
-	{
-		$formatter = new DockerPipeFormatter('ghcr.io/jqlang/jq', [], [], 'always');
-		$inputBlockString = new BlockString('', '', [new StringSegment(
-			"  {\"hello\"\n   : 	\"world\" , \"bye\":[  \"mars\" \n ]}"
-		)]);
-
-		$outputBlockString = $formatter->formatBlock($inputBlockString);
-
-		$this->assertSame(
-			<<<'JSON'
-			{
-			  "hello": "world",
-			  "bye": [
-			    "mars"
-			  ]
-			}
-			JSON,
-			implode('', $outputBlockString->segments)
+		$formatter = new DockerPipeFormatter(
+			'my-image',
+			[],
+			[],
+			'never',
+			null,
+			null,
+			$this->createProcessFactoryMock([
+				[
+					[['docker', 'image', 'inspect', 'my-image', '--format={{.Os}}/{{.Architecture}} {{.Id}}'], null, null, null],
+					$this->createProcessMock("linux/amd64 sha256:digest123\n"),
+				],
+				[
+					[['docker', 'run', '--rm', '--interactive', 'sha256:digest123'], null, null, 'input content'],
+					$this->createProcessMock('formatted content'),
+				],
+			])
 		);
+
+		$input = new BlockString('', '', [new StringSegment('input content')]);
+		$output = $formatter->formatBlock($input);
+
+		$this->assertSame('formatted content', implode('', $output->segments));
 	}
 
-	public function testBadPullMode(): void
+	public function testFormatWithAlwaysPullMode(): void
+	{
+		$formatter = new DockerPipeFormatter(
+			'my-image',
+			[],
+			[],
+			'always',
+			null,
+			null,
+			$this->createProcessFactoryMock([
+				[
+					[['docker', 'image', 'pull', 'my-image'], null, null, null],
+					$this->createProcessMock("dummy docker pull output\n"),
+				],
+				[
+					[['docker', 'image', 'inspect', 'my-image', '--format={{.Os}}/{{.Architecture}} {{.Id}}'], null, null, null],
+					$this->createProcessMock("linux/amd64 sha256:digest123\n"),
+				],
+				[
+					[['docker', 'run', '--rm', '--interactive', 'sha256:digest123'], null, null, 'input content'],
+					$this->createProcessMock('formatted content'),
+				],
+			])
+		);
+
+		$input = new BlockString('', '', [new StringSegment('input content')]);
+		$output = $formatter->formatBlock($input);
+
+		$this->assertSame('formatted content', implode('', $output->segments));
+	}
+
+	public function testFormatWithMissingPullModeWhenImageIsMissing(): void
+	{
+		$formatter = new DockerPipeFormatter(
+			'my-image',
+			[],
+			[],
+			'missing',
+			null,
+			null,
+			$this->createProcessFactoryMock([
+				[
+					[],
+					$this->createFailingProcessMock('No such image'),
+				],
+				[
+					[['docker', 'image', 'pull', 'my-image'], null, null, null],
+					$this->createProcessMock("dummy docker pull output\n"),
+				],
+				[
+					[['docker', 'image', 'inspect', 'my-image', '--format={{.Os}}/{{.Architecture}} {{.Id}}'], null, null, null],
+					$this->createProcessMock("linux/amd64 sha256:digest123\n"),
+				],
+				[
+					[['docker', 'run', '--rm', '--interactive', 'sha256:digest123'], null, null, 'input content'],
+					$this->createProcessMock('formatted content'),
+				],
+			])
+		);
+
+		$input = new BlockString('', '', [new StringSegment('input content')]);
+		$output = $formatter->formatBlock($input);
+
+		$this->assertSame('formatted content', implode('', $output->segments));
+	}
+
+	public function testInspectFailureThrowsException(): void
+	{
+		$process = $this->createMock(ProcessInterface::class);
+		$process->method('mustRun')->willThrowException(new ProcessFailedException('No such image'));
+		$process->method('getErrorOutput')->willReturn('No such image');
+
+		$processFactory = $this->createMock(ProcessFactoryInterface::class);
+		$processFactory->method('create')->willReturn($process);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('No such image');
+
+		new DockerPipeFormatter('my-image', [], [], 'never', null, null, $processFactory);
+	}
+
+	public function testInvalidPullModeThrowsException(): void
 	{
 		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Unsupported Pull Mode: invalid');
 
-		// @phpstan-ignore argument.type
-		new DockerPipeFormatter('ghcr.io/jqlang/jq', [], [], 'bad');
-	}
-
-	public function testBadImageWithoutPulling(): void
-	{
-		$this->expectException(RuntimeException::class);
-
-		new DockerPipeFormatter('docker.io/uuf6429/bad-image', [], [], 'never');
-	}
-
-	public function testBadImageWithMissingPulling(): void
-	{
-		$this->expectException(ProcessFailedException::class);
-
-		new DockerPipeFormatter('docker.io/uuf6429/bad-image', [], [], 'missing');
+		// @phpstan-ignore-next-line
+		new DockerPipeFormatter('my-image', [], [], 'invalid');
 	}
 }

--- a/tests/Unit/Formatter/WslPipeFormatterTest.php
+++ b/tests/Unit/Formatter/WslPipeFormatterTest.php
@@ -6,24 +6,33 @@ use PHPUnit\Framework\TestCase;
 use uuf6429\PhpCsFixerBlockstring\BlockString\BlockString;
 use uuf6429\PhpCsFixerBlockstring\BlockString\StringSegment;
 use uuf6429\PhpCsFixerBlockstring\Formatter\WslPipeFormatter;
+use uuf6429\PhpCsFixerBlockstringTests\MockProcessFactoryTrait;
 
 /**
  * @internal
  */
 final class WslPipeFormatterTest extends TestCase
 {
+	use MockProcessFactoryTrait;
+
 	public function testFormat(): void
 	{
-		if (PHP_OS_FAMILY !== 'Windows') {
-			$this->markTestSkipped('WSL is only available on Windows');
-		}
-		if (getenv('GITHUB_ACTIONS') === 'true') {
-			$this->markTestSkipped('WSL on GitHub Actions is poorly supported and unusable');
-		}
-
 		$formatter = new WslPipeFormatter(
 			['cmd' => 'php -v'],
-			['cmd' => ['php', '-r', 'echo strrev(stream_get_contents(STDIN));']]
+			['cmd' => ['php', '-r', 'echo strrev(stream_get_contents(STDIN));']],
+			null,
+			'login',
+			null,
+			$this->createProcessFactoryMock([
+				[
+					['wsl --shell-type login -- php -v', null, null, null],
+					$this->createProcessMock('v1.0'),
+				],
+				[
+					['wsl --shell-type login -- "php" "-r" "echo strrev(stream_get_contents(STDIN));"', null, null, 'foobar'],
+					$this->createProcessMock('raboof'),
+				]
+			])
 		);
 		$inputBlockString = new BlockString('', '', [new StringSegment('foobar')]);
 

--- a/tests/Unit/Formatter/WslPipeFormatterTest.php
+++ b/tests/Unit/Formatter/WslPipeFormatterTest.php
@@ -31,6 +31,10 @@ final class WslPipeFormatterTest extends TestCase
 				[
 					['wsl --shell-type login -- "php" "-r" "echo strrev(stream_get_contents(STDIN));"', null, null, 'foobar'],
 					$this->createProcessMock('raboof'),
+				],
+				[
+					['wsl --shell-type login -- \'php\' \'-r\' \'echo strrev(stream_get_contents(STDIN));\'', null, null, 'foobar'],
+					$this->createProcessMock('raboof'),
 				]
 			])
 		);


### PR DESCRIPTION
This changes makes it possible to replace process handling with a custom implementation. It also makes unit tests lighter and truly limited to a unit. Additionally, this fixes #4 and #10.